### PR TITLE
Added user-friendly destination names

### DIFF
--- a/coder-arguments-schema.json
+++ b/coder-arguments-schema.json
@@ -28,6 +28,10 @@
 						"type": "string",
 						"description": "Internal destination of the value"
 					},
+					"metaDest": {
+						"type": "string",
+						"description": "A user-friendly name for the value, e.g. 'verbosity_level'"
+					},
 					"type": {
 						"type": "string",
 						"enum": [

--- a/user-arguments-schema.json
+++ b/user-arguments-schema.json
@@ -76,6 +76,10 @@
 						"description": "Verbose variant of the argument (eg. --verbose)",
 						"pattern": "--[^\\s]+"
 					},
+					"metaDest": {
+						"type": "string",
+						"description": "A user-friendly name for the value, e.g. 'verbosity_level'"
+					},
 					"type": {
 						"type": "string",
 						"enum": [


### PR DESCRIPTION
Add optional strings which may be be used as placeholders when displaying help and generating example usages.